### PR TITLE
upgrade: replace "github.com/golang/protobuf/proto"

### DIFF
--- a/cmd/protoc-gen-micro/generator/name_test.go
+++ b/cmd/protoc-gen-micro/generator/name_test.go
@@ -34,7 +34,7 @@ package generator
 import (
 	"testing"
 
-	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 func TestCamelCase(t *testing.T) {
@@ -72,8 +72,8 @@ func TestGoPackageOption(t *testing.T) {
 	}
 	for _, tc := range tests {
 		d := &FileDescriptor{
-			FileDescriptorProto: &descriptor.FileDescriptorProto{
-				Options: &descriptor.FileOptions{
+			FileDescriptorProto: &descriptorpb.FileDescriptorProto{
+				Options: &descriptorpb.FileOptions{
 					GoPackage: &tc.in,
 				},
 			},

--- a/cmd/protoc-gen-micro/main.go
+++ b/cmd/protoc-gen-micro/main.go
@@ -52,9 +52,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/micro-community/micro/v3/cmd/protoc-gen-micro/generator"
 	_ "github.com/micro-community/micro/v3/cmd/protoc-gen-micro/plugin/micro"
+	"google.golang.org/protobuf/proto"
 )
 
 func main() {

--- a/cmd/protoc-gen-micro/plugin/micro/micro.go
+++ b/cmd/protoc-gen-micro/plugin/micro/micro.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
-	pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/micro-community/micro/v3/cmd/protoc-gen-micro/generator"
+
 	options "google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+	pb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // Paths for packages used by code generated in this file,
@@ -275,10 +276,10 @@ func (g *micro) generateEndpoint(servName string, method *pb.MethodDescriptorPro
 		return
 	}
 	// http rules
-	r, err := proto.GetExtension(method.Options, options.E_Http)
-	if err != nil {
-		return
-	}
+	r := proto.GetExtension(method.Options, options.E_Http)
+	// if err != nil {
+	// 	return
+	// }
 	rule := r.(*options.HttpRule)
 	var meth string
 	var path string


### PR DESCRIPTION
1. "github.com/golang/protobuf" has been superseded by the google.golang.org/protobuf module
